### PR TITLE
add new build options for WCOSS2 and Ursa to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,31 @@ ftn:   # BUILDTARGET Cray compilers
 	"OPENACC = $(OPENACC)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
+ftn:   # BUILDTARGET Cray compilers
+	( $(MAKE) all \
+	"FC_PARALLEL = ftn" \
+	"CC_PARALLEL = cc" \
+	"CXX_PARALLEL = CC" \
+	"FC_SERIAL = ftn" \
+	"CC_SERIAL = cc" \
+	"CXX_SERIAL = CC" \
+	"FFLAGS_PROMOTION = -r8" \
+	"FFLAGS_OPT = -i4 -gopt -O2 -Mvect=nosse -Kieee -convert big_endian" \
+	"CFLAGS_OPT = -fast" \
+	"CXXFLAGS_OPT = -fast" \
+	"LDFLAGS_OPT = " \
+	"FFLAGS_OMP = -mp" \
+	"CFLAGS_OMP = -mp" \
+	"FFLAGS_ACC =" \
+	"CFLAGS_ACC =" \
+	"BUILD_TARGET = $(@)" \
+	"CORE = $(CORE)" \
+	"DEBUG = $(DEBUG)" \
+	"USE_PAPI = $(USE_PAPI)" \
+	"OPENMP = $(OPENMP)" \
+	"OPENACC = $(OPENACC)" \
+	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
+
 vecna_ifort:
 	( $(MAKE) all \
 	"FC_PARALLEL = mpif90" \
@@ -399,6 +424,33 @@ ifort-gcc:   # BUILDTARGET Intel Fortran compiler and GNU C/C++ compilers
 	"LDFLAGS_DEBUG = -g -fpe0 -traceback" \
 	"FFLAGS_OMP = -qopenmp" \
 	"CFLAGS_OMP = -fopenmp" \
+	"BUILD_TARGET = $(@)" \
+	"CORE = $(CORE)" \
+	"DEBUG = $(DEBUG)" \
+	"USE_PAPI = $(USE_PAPI)" \
+	"OPENMP = $(OPENMP)" \
+	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
+
+intel-mpi:   # BUILDTARGET Intel compiler suite with Intel MPI library
+	( $(MAKE) all \
+	"FC_PARALLEL = mpiifort" \
+	"CC_PARALLEL = mpiicc" \
+	"CXX_PARALLEL = mpiicpc" \
+	"FC_SERIAL = ifort" \
+	"CC_SERIAL = icc" \
+	"CXX_SERIAL = icpc" \
+	"FFLAGS_PROMOTION = -real-size 64" \
+	"FFLAGS_OPT = -O3 -convert big_endian -free -align array64byte" \
+	"CFLAGS_OPT = -O3" \
+	"CXXFLAGS_OPT = -O3" \
+	"LDFLAGS_OPT = -O3" \
+	"FFLAGS_DEBUG = -g -convert big_endian -free -CU -CB -check all -fpe0 -traceback" \
+	"CFLAGS_DEBUG = -g -traceback" \
+	"CXXFLAGS_DEBUG = -g -traceback" \
+	"LDFLAGS_DEBUG = -g -fpe0 -traceback" \
+	"FFLAGS_OMP = -qopenmp" \
+	"CFLAGS_OMP = -qopenmp" \
+	"PICFLAG = -fpic" \
 	"BUILD_TARGET = $(@)" \
 	"CORE = $(CORE)" \
 	"DEBUG = $(DEBUG)" \

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ ftn:   # BUILDTARGET Cray compilers
 	"OPENACC = $(OPENACC)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-ftn:   # BUILDTARGET Cray compilers
+ftn-wocss2:   # wcoss2
 	( $(MAKE) all \
 	"FC_PARALLEL = ftn" \
 	"CC_PARALLEL = cc" \
@@ -129,11 +129,11 @@ ftn:   # BUILDTARGET Cray compilers
 	"FC_SERIAL = ftn" \
 	"CC_SERIAL = cc" \
 	"CXX_SERIAL = CC" \
-	"FFLAGS_PROMOTION = -r8" \
-	"FFLAGS_OPT = -i4 -gopt -O2 -Mvect=nosse -Kieee -convert big_endian" \
-	"CFLAGS_OPT = -fast" \
-	"CXXFLAGS_OPT = -fast" \
-	"LDFLAGS_OPT = " \
+	"FFLAGS_PROMOTION = -real-size 64" \
+	"FFLAGS_OPT = -O3 -convert big_endian -free -align array64byte" \
+	"CFLAGS_OPT = -O3" \
+	"CXXFLAGS_OPT = -O3" \
+	"LDFLAGS_OPT =  -O3" \
 	"FFLAGS_OMP = -mp" \
 	"CFLAGS_OMP = -mp" \
 	"FFLAGS_ACC =" \
@@ -458,14 +458,14 @@ intel-mpi:   # BUILDTARGET Intel compiler suite with Intel MPI library
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-intel-mpi:   # BUILDTARGET Intel compiler suite with Intel MPI library
+intel-mpi-ursa:   # usra
 	( $(MAKE) all \
 	"FC_PARALLEL = mpiifort" \
 	"CC_PARALLEL = mpiicc" \
 	"CXX_PARALLEL = mpiicpc" \
 	"FC_SERIAL = ifort" \
-	"CC_SERIAL = icc" \
-	"CXX_SERIAL = icpc" \
+	"CC_SERIAL = icx" \
+	"CXX_SERIAL = icpx" \
 	"FFLAGS_PROMOTION = -real-size 64" \
 	"FFLAGS_OPT = -O3 -convert big_endian -free -align array64byte" \
 	"CFLAGS_OPT = -O3" \

--- a/Makefile
+++ b/Makefile
@@ -97,23 +97,18 @@ xlf-summit-omp-offload:   # BUILDTARGET IBM XL compilers w/OpenMP offloading on 
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI -DFORTRAN_SAME -DCPRIBM -DLINUX" )
 
 ftn:   # BUILDTARGET Cray compilers
-	( PROMOTION=$${FFLAGS_PROMOTION:-"r8"}; \
-	myFFLAGS=$${FFLAGS_OPT:-"-i4 -gopt -O2 -Mvect=nosse -Kieee -convert big_endian"}; \
-	myCFLAGS=$${CFLAGS_OPT:-"-fast"}; \
-	myCXXFLAGS=$${CXXFLAGS_OPT:-"-fast"}; \
-	myLDFLAGS=$${LDFLAGS_OPT:-""}; \
-	$(MAKE) all \
+	( $(MAKE) all \
 	"FC_PARALLEL = ftn" \
 	"CC_PARALLEL = cc" \
 	"CXX_PARALLEL = CC" \
 	"FC_SERIAL = ftn" \
 	"CC_SERIAL = cc" \
 	"CXX_SERIAL = CC" \
-	"FFLAGS_PROMOTION = $${PROMOTION}" \
-	"FFLAGS_OPT = $${myFFLAGS}" \
-	"CFLAGS_OPT = $${myCFLAGS}" \
-	"CXXFLAGS_OPT = $${myCXXFLAGS}" \
-	"LDFLAGS_OPT = $${myLDFLAGS}" \
+	"FFLAGS_PROMOTION = -r8" \
+	"FFLAGS_OPT = -i4 -gopt -O2 -Mvect=nosse -Kieee -convert big_endian" \
+	"CFLAGS_OPT = -fast" \
+	"CXXFLAGS_OPT = -fast" \
+	"LDFLAGS_OPT = " \
 	"FFLAGS_OMP = -mp" \
 	"CFLAGS_OMP = -mp" \
 	"FFLAGS_ACC =" \
@@ -412,15 +407,13 @@ ifort-gcc:   # BUILDTARGET Intel Fortran compiler and GNU C/C++ compilers
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
 intel-mpi:   # BUILDTARGET Intel compiler suite with Intel MPI library
-	( CC_STR=$${CC_SERIAL:-icc}; \
-	CXX_STR=$${CXX_SERIAL:-icpc}; \
-	$(MAKE) all \
+	( $(MAKE) all \
 	"FC_PARALLEL = mpiifort" \
 	"CC_PARALLEL = mpiicc" \
 	"CXX_PARALLEL = mpiicpc" \
 	"FC_SERIAL = ifort" \
-	"CC_SERIAL = $${CC_STR}" \
-	"CXX_SERIAL = $${CXX_STR}" \
+	"CC_SERIAL = icc" \
+	"CXX_SERIAL = icpc" \
 	"FFLAGS_PROMOTION = -real-size 64" \
 	"FFLAGS_OPT = -O3 -convert big_endian -free -align array64byte" \
 	"CFLAGS_OPT = -O3" \


### PR DESCRIPTION
Based on the conversation in https://github.com/ufs-community/MPAS-Model/pull/141, we want to add new build options for WCOSS2 and Ursa. This keeps the default options intact so that it is easier to sync with NCAR's MPAS-Model.