### PR TITLE
Revert "report MPAS_IO_ERR_UNDEFINED_VAR as a warning instead of an error"

### DIFF
--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -6479,7 +6479,7 @@ module mpas_io
          case (MPAS_IO_ERR_UNDEFINED_DIM)
             call mpas_log_write('MPAS IO Error: Field uses undefined dimension', MPAS_LOG_ERR)
          case (MPAS_IO_ERR_UNDEFINED_VAR)
-            call mpas_log_write('MPAS IO Error: Undefined field', MPAS_LOG_WARN)
+            call mpas_log_write('MPAS IO Error: Undefined field', MPAS_LOG_ERR)
          case (MPAS_IO_ERR_REDEF_ATT)
             call mpas_log_write('MPAS IO Error: Inconsistent redefinition of attribute', MPAS_LOG_ERR)
          case (MPAS_IO_ERR_WRONG_ATT_TYPE)


### PR DESCRIPTION
Reverts RRFSx/MPAS-Model#6