### PR TITLE
Bugfix to define global attributes (and remove some unneeded code)

### DIFF
--- a/src/framework/mpas_io_streams.F
+++ b/src/framework/mpas_io_streams.F
@@ -4176,6 +4176,7 @@ module mpas_io_streams
 
 
    logical function MPAS_checkStreamAtt(stream, attName, ierr)
+     ! Returns .true. if we can write the attribute.
 
       implicit none
 
@@ -4195,6 +4196,12 @@ module mpas_io_streams
          if (present(ierr)) ierr = MPAS_STREAM_NOT_INITIALIZED
          return
       end if
+      if (.not. stream % fileHandle % data_mode) then
+         ! Can always write an attribute in define mode.
+         STREAM_DEBUG_WRITE('Able to write attribute "' // trim(attName) // '" in define mode.')
+         MPAS_checkStreamAtt = .true.
+         return
+      endif
       call MPAS_io_has_att(stream % fileHandle, attName, ierr=io_err) 
       if(io_err /= 0) then
          return
@@ -4226,10 +4233,7 @@ module mpas_io_streams
          if (present(ierr)) ierr = MPAS_STREAM_NOT_INITIALIZED
          return
       end if
-      call MPAS_io_has_att(stream % fileHandle, attName, ierr=io_err) 
-      if(io_err /= 0) then
-         return
-      endif
+
       call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err) 
       call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR


### PR DESCRIPTION
Bug fix: write global attributes from forecast.

As documented here:

- https://github.com/NOAA-EMC/rrfs-workflow/pull/949

In the comment chain, it was noted that the current gsl/develop cannot write global attributes.

- https://github.com/NOAA-EMC/rrfs-workflow/pull/949#issuecomment-3358744438

The bug is caused by a workaround I added to let jedivar write to init.nc. Jedivar was trying to write to undefined global attributes in data mode. My workaround was to not write to attributes unless they're defined. That prevented them from being defined in define mode (since nothing is defined yet).

The fix is to always allow writing global attributes in define mode.

Information on running mandatory regression tests on Jet can be found [here](https://github.com/barlage/mpas_testcase) and the results pasted below.

<details>
  <summary>
    regression test case results
  </summary>
  
```
PASTE compare_run_testcases AND/OR compare_create_testcases TEXT HERE
```
</details>
