### PR TITLE
Add checks for smoke/dust scheme before filling ic/bc arrays

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -4108,7 +4108,6 @@ module init_atm_cases
       integer :: nfglevels_actual
       integer, pointer :: index_qv, index_qc, index_qr, index_qi, index_qs, index_qg, index_ni, index_nc, index_nr, index_ns, index_ng
       integer, pointer :: index_nwfa, index_nifa
-      integer, pointer :: index_massden
       integer, pointer :: index_smoke_fine, index_dust_fine, index_dust_coarse
 
       integer, dimension(5) :: interp_list
@@ -4126,7 +4125,7 @@ module init_atm_cases
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ1,sorted_arrQ2,sorted_arrQ3,sorted_arrQ4,sorted_arrQ5,sorted_arrQ6,sorted_arrQ7,sorted_arrQ8
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ9,sorted_arrQ10
 ! Chemistry
-      real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ11,sorted_arrQ12,sorted_arrQ14,sorted_arrQ15
+      real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ11,sorted_arrQ12,sorted_arrQ13
 
 
       integer, dimension(:), pointer :: bdyMaskCell
@@ -4194,6 +4193,7 @@ module init_atm_cases
       integer, pointer :: config_theta_adv_order
       real (kind=RKIND), pointer :: config_coef_3rd_order
       logical, pointer :: config_blend_bdy_terrain
+      character (len=StrKIND), pointer :: config_smoke_scheme, config_dust_scheme
 
       character (len=StrKIND), pointer :: config_extrap_airtemp
       integer :: extrap_airtemp
@@ -4257,7 +4257,6 @@ module init_atm_cases
       real (kind=RKIND), dimension(:,:), pointer :: sm_fg
       real (kind=RKIND), dimension(:), pointer :: soilz
 ! Chemistry
-      real (kind=RKIND), dimension(:,:), pointer :: massden_fg
       real (kind=RKIND), dimension(:,:), pointer :: smoke_fine_fg
       real (kind=RKIND), dimension(:,:), pointer :: dust_fine_fg
       real (kind=RKIND), dimension(:,:), pointer :: dust_coarse_fg
@@ -4297,6 +4296,8 @@ module init_atm_cases
       call mpas_pool_get_config(configs, 'config_coef_3rd_order', config_coef_3rd_order)
       call mpas_pool_get_config(configs, 'config_blend_bdy_terrain', config_blend_bdy_terrain)
       call mpas_pool_get_config(configs, 'config_interface_projection', config_interface_projection)
+      call mpas_pool_get_config(configs, 'config_smoke_scheme', config_smoke_scheme)
+      call mpas_pool_get_config(configs, 'config_dust_scheme', config_dust_scheme)
       
       call mpas_pool_get_config(configs, 'config_extrap_airtemp', config_extrap_airtemp)
       if (trim(config_extrap_airtemp) == 'constant') then
@@ -4418,10 +4419,13 @@ module init_atm_cases
       call mpas_pool_get_array(fg, 'gfs_z', gfs_z)
       call mpas_pool_get_array(fg, 'p', p_fg)
 ! Chemistry
-      call mpas_pool_get_array(fg, 'MASSDEN', massden_fg)
-      call mpas_pool_get_array(fg, 'smoke_fine', smoke_fine_fg)
-      call mpas_pool_get_array(fg, 'dust_fine', dust_fine_fg)
-      call mpas_pool_get_array(fg, 'dust_coarse', dust_coarse_fg)
+      if ( config_smoke_scheme .ne. 'off' ) then
+         call mpas_pool_get_array(fg, 'smoke_fine', smoke_fine_fg)
+      endif
+      if ( config_dust_scheme .ne. 'off' ) then
+         call mpas_pool_get_array(fg, 'dust_fine', dust_fine_fg)
+         call mpas_pool_get_array(fg, 'dust_coarse', dust_coarse_fg)
+      endif
 
       call mpas_pool_get_dimension(dims, 'nVertLevels', nz1)
       call mpas_pool_get_dimension(dims, 'nCellsSolve', nCellsSolve)
@@ -4442,10 +4446,13 @@ module init_atm_cases
       call mpas_pool_get_dimension(state, 'index_ns', index_ns)
       call mpas_pool_get_dimension(state, 'index_ng', index_ng)
 ! Chemistry
-      call mpas_pool_get_dimension(state, 'index_MASSDEN',index_massden)
-      call mpas_pool_get_dimension(state, 'index_smoke_fine',index_smoke_fine)
-      call mpas_pool_get_dimension(state, 'index_dust_fine',index_dust_fine)
-      call mpas_pool_get_dimension(state, 'index_dust_coarse',index_dust_coarse)
+      if ( config_smoke_scheme .ne. 'off' ) then
+         call mpas_pool_get_dimension(state, 'index_smoke_fine',index_smoke_fine)
+      endif
+      if ( config_dust_scheme .ne. 'off' ) then
+         call mpas_pool_get_dimension(state, 'index_dust_fine',index_dust_fine)
+         call mpas_pool_get_dimension(state, 'index_dust_coarse',index_dust_coarse)
+      endif
 
       xnutr = 0.
       zd = 12000.
@@ -5072,7 +5079,6 @@ module init_atm_cases
              trim(field % field) == 'SEAICE' .or. &
              trim(field % field) == 'SKINTEMP' .or. &
 ! Chemistry
-             trim(field % field) == 'MASSDEN' .or. &
              trim(field % field) == 'SMKF' .or. &
              trim(field % field) == 'DSTF' .or. &
              trim(field % field) == 'DSTC') then
@@ -5363,34 +5369,33 @@ module init_atm_cases
                 call mpas_pool_get_array(fg, 'qni', destField2d)
                 ndims = 2
 ! Chemistry
-            else if (trim(field % field) == 'MASSDEN' ) then
-                call mpas_log_write('Interpolating MASSDEN at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
-                nInterpPoints = nCells
-                latPoints => latCell
-                lonPoints => lonCell
-                call mpas_pool_get_array(fg, 'MASSDEN', destField2d)
-                ndims = 2
             else if (trim(field % field) == 'SMKF' ) then
+              if ( config_smoke_scheme .ne. 'off' ) then
                 call mpas_log_write('Interpolating SMKFN at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
                 nInterpPoints = nCells
                 latPoints => latCell
                 lonPoints => lonCell
                 call mpas_pool_get_array(fg, 'smoke_fine', destField2d)
                 ndims = 2
+              endif
             else if (trim(field % field) == 'DSTF' ) then
+              if ( config_dust_scheme .ne. 'off' ) then
                 call mpas_log_write('Interpolating DSTFN at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
                 nInterpPoints = nCells
                 latPoints => latCell
                 lonPoints => lonCell
                 call mpas_pool_get_array(fg, 'dust_fine', destField2d)
                 ndims = 2
+              endif
             else if (trim(field % field) == 'DSTC' ) then
+              if ( config_dust_scheme .ne. 'off' ) then
                 call mpas_log_write('Interpolating DUSTC at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
                 nInterpPoints = nCells
                 latPoints => latCell
                 lonPoints => lonCell
                 call mpas_pool_get_array(fg, 'dust_coarse', destField2d)
                 ndims = 2
+              endif
             else if (trim(field % field) == 'GHT') then
                call mpas_log_write('Interpolating GHT at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
                nInterpPoints = nCells
@@ -7172,10 +7177,9 @@ call mpas_log_write('Done with soil consistency check')
       allocate(sorted_arrQ9(2,nfglevels_actual))
       allocate(sorted_arrQ10(2,nfglevels_actual))
 ! Chemistry
-      if (associated(index_massden      )) allocate(sorted_arrQ11(2,nfglevels_actual))
-      if (associated(index_smoke_fine   )) allocate(sorted_arrQ12(2,nfglevels_actual))
-      if (associated(index_dust_fine    )) allocate(sorted_arrQ14(2,nfglevels_actual))
-      if (associated(index_dust_coarse  )) allocate(sorted_arrQ15(2,nfglevels_actual))
+      if (associated(index_smoke_fine   )) allocate(sorted_arrQ11(2,nfglevels_actual))
+      if (associated(index_dust_fine    )) allocate(sorted_arrQ12(2,nfglevels_actual))
+      if (associated(index_dust_coarse  )) allocate(sorted_arrQ13(2,nfglevels_actual))
 
       call mpas_log_write('min lon $r max lon $r min lat $r max lat $r',realArgs=(/minval(lonPoints),maxval(lonPoints),minval(latPoints),maxval(latPoints)/))
       do iCell=1,nCells
@@ -7253,10 +7257,9 @@ call mpas_log_write('Done with soil consistency check')
          sorted_arrQ9(:,:) = -999.0
          sorted_arrQ10(:,:) = -999.0
 ! Chemistry
-         if (associated(index_massden     ) ) sorted_arrQ11(:,:) = -999.0
-         if (associated(index_smoke_fine  ) ) sorted_arrQ12(:,:) = -999.0
-         if (associated(index_dust_fine   ) ) sorted_arrQ14(:,:) = -999.0
-         if (associated(index_dust_coarse ) ) sorted_arrQ15(:,:) = -999.0
+         if (associated(index_smoke_fine  ) ) sorted_arrQ11(:,:) = -999.0
+         if (associated(index_dust_fine   ) ) sorted_arrQ12(:,:) = -999.0
+         if (associated(index_dust_coarse ) ) sorted_arrQ13(:,:) = -999.0
          scalars(index_nwfa,:,iCell) = 0._RKIND
          scalars(index_nifa,:,iCell) = 0._RKIND
          scalars(index_qc,:,iCell) = 0._RKIND
@@ -7270,9 +7273,6 @@ call mpas_log_write('Done with soil consistency check')
          scalars(index_ns,:,iCell) = 0._RKIND
          scalars(index_ng,:,iCell) = 0._RKIND
 ! Chemistry
-         if (associated(index_massden        )) then
-            if  (index_massden > 0      ) scalars(index_massden,:,iCell) = 0._RKIND
-         endif
          if (associated(index_smoke_fine     )) then
             if (index_smoke_fine > 0    ) scalars(index_smoke_fine,:,iCell) = 0._RKIND
          endif
@@ -7294,10 +7294,9 @@ call mpas_log_write('Done with soil consistency check')
             sorted_arrQ9(1,k) = z_fg(k,iCell)
             sorted_arrQ10(1,k) = z_fg(k,iCell)
 ! Chemistry
-            if (associated(index_massden     ) ) sorted_arrQ11(1,k) = z_fg(k,iCell)
-            if (associated(index_smoke_fine  ) ) sorted_arrQ12(1,k) = z_fg(k,iCell)
-            if (associated(index_dust_fine   ) ) sorted_arrQ14(1,k) = z_fg(k,iCell)
-            if (associated(index_dust_coarse ) ) sorted_arrQ15(1,k) = z_fg(k,iCell)
+            if (associated(index_smoke_fine  ) ) sorted_arrQ11(1,k) = z_fg(k,iCell)
+            if (associated(index_dust_fine   ) ) sorted_arrQ12(1,k) = z_fg(k,iCell)
+            if (associated(index_dust_coarse ) ) sorted_arrQ13(1,k) = z_fg(k,iCell)
             if (vert_level(k) == 200100.0) then
                 sorted_arrQ1(1,k) = 99999.0
                 sorted_arrQ2(1,k) = 99999.0
@@ -7310,10 +7309,9 @@ call mpas_log_write('Done with soil consistency check')
                 sorted_arrQ9(1,k) = 99999.0
                 sorted_arrQ10(1,k) = 99999.0
 ! Chemistry
-                if (associated(index_massden     ) ) sorted_arrQ11(1,k) = 99999.0
-                if (associated(index_smoke_fine  ) ) sorted_arrQ12(1,k) = 99999.0
-                if (associated(index_dust_fine   ) ) sorted_arrQ14(1,k) = 99999.0
-                if (associated(index_dust_coarse ) ) sorted_arrQ15(1,k) = 99999.0
+                if (associated(index_smoke_fine  ) ) sorted_arrQ11(1,k) = 99999.0
+                if (associated(index_dust_fine   ) ) sorted_arrQ12(1,k) = 99999.0
+                if (associated(index_dust_coarse ) ) sorted_arrQ13(1,k) = 99999.0
             endif
             sorted_arrQ1(2,k) = max(0._RKIND,qc_fg(k,iCell))
             sorted_arrQ2(2,k) = max(0._RKIND,qr_fg(k,iCell))
@@ -7326,10 +7324,9 @@ call mpas_log_write('Done with soil consistency check')
             sorted_arrQ9(2,k) = max(0._RKIND,qnwfa_fg(k,iCell))
             sorted_arrQ10(2,k) = max(0._RKIND,qnifa_fg(k,iCell))
 ! Chemistry
-            if (associated(massden_fg     ) ) sorted_arrQ11(2,k) = max(0._RKIND,massden_fg(k,iCell))
-            if (associated(smoke_fine_fg  ) ) sorted_arrQ12(2,k) = max(0._RKIND,smoke_fine_fg(k,iCell))
-            if (associated(dust_fine_fg   ) ) sorted_arrQ14(2,k) = max(0._RKIND,dust_fine_fg(k,iCell))
-            if (associated(dust_coarse_fg ) ) sorted_arrQ15(2,k) = max(0._RKIND,dust_coarse_fg(k,iCell))
+            if (associated(smoke_fine_fg  ) ) sorted_arrQ11(2,k) = max(0._RKIND,smoke_fine_fg(k,iCell))
+            if (associated(dust_fine_fg   ) ) sorted_arrQ12(2,k) = max(0._RKIND,dust_fine_fg(k,iCell))
+            if (associated(dust_coarse_fg ) ) sorted_arrQ13(2,k) = max(0._RKIND,dust_coarse_fg(k,iCell))
          end do
 
          call mpas_quicksort(nfglevels_actual, sorted_arrQ1)
@@ -7343,10 +7340,9 @@ call mpas_log_write('Done with soil consistency check')
          call mpas_quicksort(nfglevels_actual, sorted_arrQ9)
          call mpas_quicksort(nfglevels_actual, sorted_arrQ10)
 ! Chemistry
-         if (associated(index_massden      ) )   call mpas_quicksort(nfglevels_actual, sorted_arrQ11)
-         if (associated(index_smoke_fine   ) )   call mpas_quicksort(nfglevels_actual, sorted_arrQ12)
-         if (associated(index_dust_fine    ) )  call mpas_quicksort(nfglevels_actual, sorted_arrQ14)
-         if (associated(index_dust_coarse  ) )  call mpas_quicksort(nfglevels_actual, sorted_arrQ15)
+         if (associated(index_smoke_fine   ) )  call mpas_quicksort(nfglevels_actual, sorted_arrQ11)
+         if (associated(index_dust_fine    ) )  call mpas_quicksort(nfglevels_actual, sorted_arrQ12)
+         if (associated(index_dust_coarse  ) )  call mpas_quicksort(nfglevels_actual, sorted_arrQ13)
 
          do k = nVertLevels, 1, -1
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
@@ -7371,21 +7367,17 @@ call mpas_log_write('Done with soil consistency check')
             scalars(index_nr,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ8(:,1:nfglevels_actual-1), order=1, extrap=0)
 ! Chemistry
-            if ( associated(index_massden)) then
-               if (  index_massden > 0      ) scalars(index_massden,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
-                                        sorted_arrQ11(:,1:nfglevels_actual-1), order=1, extrap=0)
-            endif
             if ( associated(index_smoke_fine)) then
                 if ( index_smoke_fine > 0 ) scalars(index_smoke_fine,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
-                                        sorted_arrQ12(:,1:nfglevels_actual-1), order=1, extrap=0)
+                                        sorted_arrQ11(:,1:nfglevels_actual-1), order=1, extrap=0)
             endif
             if ( associated(index_dust_fine )) then
                if ( index_dust_fine > 0  ) scalars(index_dust_fine,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
-                                        sorted_arrQ14(:,1:nfglevels_actual-1), order=1, extrap=0)
+                                        sorted_arrQ12(:,1:nfglevels_actual-1), order=1, extrap=0)
             endif
             if ( associated(index_dust_coarse )) then
                if ( index_dust_coarse > 0 ) scalars(index_dust_coarse,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
-                                        sorted_arrQ15(:,1:nfglevels_actual-1), order=1, extrap=0)
+                                        sorted_arrQ13(:,1:nfglevels_actual-1), order=1, extrap=0)
             endif
          end do
 
@@ -7489,10 +7481,9 @@ call mpas_log_write('Done with soil consistency check')
       deallocate(sorted_arr)
       deallocate(sorted_arrQ1,sorted_arrQ2,sorted_arrQ3,sorted_arrQ4,sorted_arrQ5,sorted_arrQ6,sorted_arrQ7,sorted_arrQ8,sorted_arrQ9,sorted_arrQ10)
 ! Chemistry
-      if (associated(index_massden     )) deallocate(sorted_arrQ11)
-      if (associated(index_smoke_fine  )) deallocate(sorted_arrQ12)
-      if (associated(index_dust_fine   )) deallocate(sorted_arrQ14)
-      if (associated(index_dust_coarse )) deallocate(sorted_arrQ15)
+      if (associated(index_smoke_fine  )) deallocate(sorted_arrQ11)
+      if (associated(index_dust_fine   )) deallocate(sorted_arrQ12)
+      if (associated(index_dust_coarse )) deallocate(sorted_arrQ13)
 
       ! Diagnose the water vapor mixing ratios:
       global_sh_min = 0._RKIND
@@ -7819,7 +7810,6 @@ call mpas_log_write('Done with soil consistency check')
       integer, pointer :: index_qv, index_qc, index_qr, index_qi, index_qs, index_qg,index_ni, index_nc, index_nr, index_ns, index_ng
       integer, pointer :: index_nwfa, index_nifa
 ! Chemistry
-      integer, pointer :: index_massden
       integer, pointer :: index_smoke_fine, index_dust_fine, index_dust_coarse
 
 
@@ -7833,7 +7823,7 @@ call mpas_log_write('Done with soil consistency check')
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ1,sorted_arrQ2,sorted_arrQ3,sorted_arrQ4,sorted_arrQ5,sorted_arrQ6,sorted_arrQ7,sorted_arrQ8
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ9,sorted_arrQ10
 ! Chemistry
-      real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ11,sorted_arrQ12,sorted_arrQ14,sorted_arrQ15
+      real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ11,sorted_arrQ12,sorted_arrQ13
 
       integer :: sfc_k
 
@@ -7863,6 +7853,7 @@ call mpas_log_write('Done with soil consistency check')
       real (kind=RKIND), pointer :: config_coef_3rd_order
 
       character (len=StrKIND), pointer :: config_extrap_airtemp
+      character (len=StrKIND), pointer :: config_smoke_scheme, config_dust_scheme
       integer :: extrap_airtemp
 
       real (kind=RKIND), dimension(:), pointer :: latCell, lonCell
@@ -7895,7 +7886,6 @@ call mpas_log_write('Done with soil consistency check')
       real (kind=RKIND), dimension(:,:), pointer :: qni_fg
       real (kind=RKIND), dimension(:,:), pointer :: qnr_fg
 ! Chemistry
-      real (kind=RKIND), dimension(:,:), pointer :: massden_fg
       real (kind=RKIND), dimension(:,:), pointer :: smoke_fine_fg, dust_fine_fg, dust_coarse_fg
 
       real (kind=RKIND), dimension(:,:), pointer :: p_fg
@@ -7994,10 +7984,15 @@ call mpas_log_write('Done with soil consistency check')
       call mpas_pool_get_array(fg, 'qni', qni_fg)
       call mpas_pool_get_array(fg, 'qnr', qnr_fg)
 ! Chemistry
-      call mpas_pool_get_array(fg, 'MASSDEN', massden_fg)
-      call mpas_pool_get_array(fg, 'smoke_fine', smoke_fine_fg)
-      call mpas_pool_get_array(fg, 'dust_fine', dust_fine_fg)
-      call mpas_pool_get_array(fg, 'dust_coarse', dust_coarse_fg)
+      call mpas_pool_get_config(configs, 'config_smoke_scheme', config_smoke_scheme)
+      call mpas_pool_get_config(configs, 'config_dust_scheme', config_dust_scheme)
+      if ( config_smoke_scheme .ne. 'off' ) then
+         call mpas_pool_get_array(fg, 'smoke_fine', smoke_fine_fg)
+      endif
+      if ( config_dust_scheme .ne. 'off' ) then
+         call mpas_pool_get_array(fg, 'dust_fine', dust_fine_fg)
+         call mpas_pool_get_array(fg, 'dust_coarse', dust_coarse_fg)
+      endif
 
       call mpas_pool_get_array(fg, 'p', p_fg)
 
@@ -8019,10 +8014,13 @@ call mpas_log_write('Done with soil consistency check')
       call mpas_pool_get_dimension(lbc_state, 'index_lbc_ns', index_ns)
       call mpas_pool_get_dimension(lbc_state, 'index_lbc_ng', index_ng)
 ! Chemistry
-      call mpas_pool_get_dimension(lbc_state, 'index_lbc_MASSDEN', index_massden)
-      call mpas_pool_get_dimension(lbc_state, 'index_lbc_smoke_fine', index_smoke_fine)
-      call mpas_pool_get_dimension(lbc_state, 'index_lbc_dust_fine', index_dust_fine)
-      call mpas_pool_get_dimension(lbc_state, 'index_lbc_dust_coarse', index_dust_coarse)
+      if ( config_smoke_scheme .ne. 'off' ) then
+         call mpas_pool_get_dimension(lbc_state, 'index_lbc_smoke_fine', index_smoke_fine)
+      endif
+      if ( config_dust_scheme .ne. 'off' ) then
+         call mpas_pool_get_dimension(lbc_state, 'index_lbc_dust_fine', index_dust_fine)
+         call mpas_pool_get_dimension(lbc_state, 'index_lbc_dust_coarse', index_dust_coarse)
+      endif
 
       etavs = (1.0_RKIND - 0.252_RKIND) * pii / 2.0_RKIND
       rcv = rgas / (cp - rgas)
@@ -8101,7 +8099,6 @@ call mpas_log_write('Done with soil consistency check')
              trim(field % field) == 'PRES' .or. &
              trim(field % field) == 'PRESSURE'.or. &
 ! Chemistry
-             trim(field % field) == 'MASSDEN' .or. &
              trim(field % field) == 'SMKF' .or. &
              trim(field % field) == 'DSTF' .or. &
              trim(field % field) == 'DSTC') then
@@ -8325,34 +8322,33 @@ call mpas_log_write('Done with soil consistency check')
                call mpas_pool_get_array(fg, 'soilz', destField1d)
                ndims = 1
 ! Chemistry
-            else if (trim(field % field) == 'MASSDEN' ) then
-                call mpas_log_write('Interpolating MASSDEN at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
-                nInterpPoints = nCells
-                latPoints => latCell
-                lonPoints => lonCell
-                call mpas_pool_get_array(fg, 'MASSDEN', destField2d)
-                ndims = 2
             else if (trim(field % field) == 'SMKF' ) then
+              if (config_smoke_scheme .ne. 'off' ) then
                 call mpas_log_write('Interpolating SMKF at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
                 nInterpPoints = nCells
                 latPoints => latCell
                 lonPoints => lonCell
                 call mpas_pool_get_array(fg, 'smoke_fine', destField2d)
                 ndims = 2
+              endif
             else if (trim(field % field) == 'DSTF' ) then
+              if (config_dust_scheme .ne. 'off' ) then
                 call mpas_log_write('Interpolating DSTF at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
                 nInterpPoints = nCells
                 latPoints => latCell
                 lonPoints => lonCell
                 call mpas_pool_get_array(fg, 'dust_fine', destField2d)
                 ndims = 2
+              endif
             else if (trim(field % field) == 'DSTC' ) then
+              if (config_dust_scheme .ne. 'off' ) then
                 call mpas_log_write('Interpolating DSTC at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
                 nInterpPoints = nCells
                 latPoints => latCell
                 lonPoints => lonCell
                 call mpas_pool_get_array(fg, 'dust_coarse', destField2d)
                 ndims = 2
+              endif
             end if
 
             allocate(rslab(-2:field % nx+3, field % ny))
@@ -8500,10 +8496,9 @@ call mpas_log_write('Done with soil consistency check')
       allocate(sorted_arrQ9(2,nfglevels_actual))
       allocate(sorted_arrQ10(2,nfglevels_actual))
 ! Chemistry
-      if (associated(index_massden     )) allocate(sorted_arrQ11(2,nfglevels_actual))
-      if (associated(index_smoke_fine  )) allocate(sorted_arrQ12(2,nfglevels_actual))
-      if (associated(index_dust_fine   )) allocate(sorted_arrQ14(2,nfglevels_actual))
-      if (associated(index_dust_coarse )) allocate(sorted_arrQ15(2,nfglevels_actual))
+      if (associated(index_smoke_fine  )) allocate(sorted_arrQ11(2,nfglevels_actual))
+      if (associated(index_dust_fine   )) allocate(sorted_arrQ12(2,nfglevels_actual))
+      if (associated(index_dust_coarse )) allocate(sorted_arrQ13(2,nfglevels_actual))
 
       do iCell=1,nCells
 
@@ -8573,10 +8568,9 @@ call mpas_log_write('Done with soil consistency check')
          sorted_arrQ9(:,:) = -999.0
          sorted_arrQ10(:,:) = -999.0
 ! Chemistry
-         if (associated(index_massden     )) sorted_arrQ11(:,:) = -999.0
-         if (associated(index_smoke_fine  )) sorted_arrQ12(:,:) = -999.0
-         if (associated(index_dust_fine   )) sorted_arrQ14(:,:) = -999.0
-         if (associated(index_dust_coarse )) sorted_arrQ15(:,:) = -999.0
+         if (associated(index_smoke_fine  )) sorted_arrQ11(:,:) = -999.0
+         if (associated(index_dust_fine   )) sorted_arrQ12(:,:) = -999.0
+         if (associated(index_dust_coarse )) sorted_arrQ13(:,:) = -999.0
          scalars(index_nwfa,:,iCell) = 0._RKIND
          scalars(index_nifa,:,iCell) = 0._RKIND
          scalars(index_qc,:,iCell) = 0._RKIND
@@ -8590,9 +8584,6 @@ call mpas_log_write('Done with soil consistency check')
          scalars(index_ns,:,iCell) = 0._RKIND
          scalars(index_ng,:,iCell) = 0._RKIND
 ! Chemistry
-         if (associated(index_massden      )) then
-            if (index_massden > 0      )  scalars(index_massden,:,iCell) = 0._RKIND
-         endif
          if (associated(index_smoke_fine   )) then
             if (index_smoke_fine > 0   )  scalars(index_smoke_fine,:,iCell) = 0._RKIND
          endif
@@ -8615,10 +8606,9 @@ call mpas_log_write('Done with soil consistency check')
             sorted_arrQ9(1,k) = z_fg(k,iCell)
             sorted_arrQ10(1,k) = z_fg(k,iCell)
 ! Chemistry
-           if (associated(index_massden     )) sorted_arrQ11(1,k) = z_fg(k,iCell)
-           if (associated(index_smoke_fine  )) sorted_arrQ12(1,k) = z_fg(k,iCell)
-           if (associated(index_dust_fine   )) sorted_arrQ14(1,k) = z_fg(k,iCell)
-           if (associated(index_dust_coarse )) sorted_arrQ15(1,k) = z_fg(k,iCell)
+           if (associated(index_smoke_fine  )) sorted_arrQ11(1,k) = z_fg(k,iCell)
+           if (associated(index_dust_fine   )) sorted_arrQ12(1,k) = z_fg(k,iCell)
+           if (associated(index_dust_coarse )) sorted_arrQ13(1,k) = z_fg(k,iCell)
             if (vert_level(k) == 200100.0) then
                 sorted_arrQ1(1,k) = 99999.0
                 sorted_arrQ2(1,k) = 99999.0
@@ -8631,10 +8621,9 @@ call mpas_log_write('Done with soil consistency check')
                 sorted_arrQ9(1,k) = 99999.0
                 sorted_arrQ10(1,k) = 99999.0
 ! Chemistry
-                if (associated(index_massden     )) sorted_arrQ11(1,k) = 99999.0
-                if (associated(index_smoke_fine  )) sorted_arrQ12(1,k) = 99999.0
-                if (associated(index_dust_fine   )) sorted_arrQ14(1,k) = 99999.0
-                if (associated(index_dust_coarse )) sorted_arrQ15(1,k) = 99999.0
+                if (associated(index_smoke_fine  )) sorted_arrQ11(1,k) = 99999.0
+                if (associated(index_dust_fine   )) sorted_arrQ12(1,k) = 99999.0
+                if (associated(index_dust_coarse )) sorted_arrQ13(1,k) = 99999.0
              endif
             sorted_arrQ1(2,k) = max(0._RKIND,qc_fg(k,iCell))
             sorted_arrQ2(2,k) = max(0._RKIND,qr_fg(k,iCell))
@@ -8647,10 +8636,9 @@ call mpas_log_write('Done with soil consistency check')
             sorted_arrQ9(2,k) = max(0._RKIND,qnwfa_fg(k,iCell))
             sorted_arrQ10(2,k) = max(0._RKIND,qnifa_fg(k,iCell))
 ! Chemistry
-            if (associated(massden_fg     ))sorted_arrQ11(2,k) = max(0._RKIND,massden_fg(k,iCell))
-            if (associated(smoke_fine_fg  ))sorted_arrq12(2,k) = max(0._rkind,smoke_fine_fg(k,icell))
-            if (associated(dust_fine_fg   ))sorted_arrq14(2,k) = max(0._rkind,dust_fine_fg(k,icell))
-            if (associated(dust_coarse_fg ))sorted_arrq15(2,k) = max(0._rkind,dust_coarse_fg(k,icell))
+            if (associated(smoke_fine_fg  ))sorted_arrq11(2,k) = max(0._rkind,smoke_fine_fg(k,icell))
+            if (associated(dust_fine_fg   ))sorted_arrq12(2,k) = max(0._rkind,dust_fine_fg(k,icell))
+            if (associated(dust_coarse_fg ))sorted_arrq13(2,k) = max(0._rkind,dust_coarse_fg(k,icell))
          end do
 
          call mpas_quicksort(nfglevels_actual, sorted_arrQ1)
@@ -8664,10 +8652,9 @@ call mpas_log_write('Done with soil consistency check')
          call mpas_quicksort(nfglevels_actual, sorted_arrQ9)
          call mpas_quicksort(nfglevels_actual, sorted_arrQ10)
 ! Chemistry
-         if (associated(index_massden     ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ11)
-         if (associated(index_smoke_fine  ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ12)
-         if (associated(index_dust_fine   ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ14)
-         if (associated(index_dust_coarse ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ15)
+         if (associated(index_smoke_fine  ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ11)
+         if (associated(index_dust_fine   ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ12)
+         if (associated(index_dust_coarse ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ13)
          do k = nVertLevels, 1, -1
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
             scalars(index_nwfa,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
@@ -8691,21 +8678,17 @@ call mpas_log_write('Done with soil consistency check')
             scalars(index_nr,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ8(:,1:nfglevels_actual-1), order=1, extrap=0)
 ! JLS
-            if ( associated(index_massden )) then
-               if (  index_massden > 0    ) scalars(index_massden,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
-                                        sorted_arrQ11(:,1:nfglevels_actual-1), order=1, extrap=0)
-            endif
             if ( associated(index_smoke_fine )) then
                 if ( index_smoke_fine > 0  ) scalars(index_smoke_fine,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
-                                        sorted_arrQ12(:,1:nfglevels_actual-1), order=1, extrap=0)
+                                        sorted_arrQ11(:,1:nfglevels_actual-1), order=1, extrap=0)
             endif
             if ( associated(index_dust_fine )) then
                if ( index_dust_fine > 0) scalars(index_dust_fine,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
-                                        sorted_arrQ14(:,1:nfglevels_actual-1), order=1, extrap=0)
+                                        sorted_arrQ12(:,1:nfglevels_actual-1), order=1, extrap=0)
             endif
             if ( associated(index_dust_coarse )) then
                if ( index_dust_coarse > 0) scalars(index_dust_coarse,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
-                                        sorted_arrQ15(:,1:nfglevels_actual-1), order=1, extrap=0)
+                                        sorted_arrQ13(:,1:nfglevels_actual-1), order=1, extrap=0)
             endif
             if (target_z < z_fg(1,iCell) .and. k < nVertLevels) then
                 scalars(index_nwfa,k,iCell) = scalars(index_nwfa,k+1,iCell)
@@ -8721,9 +8704,6 @@ call mpas_log_write('Done with soil consistency check')
                 scalars(index_ns,k,iCell) = scalars(index_ns,k+1,iCell)
                 scalars(index_ng,k,iCell) = scalars(index_ng,k+1,iCell)
 ! Chemistry
-                if ( associated(index_massden     )) then
-                   if (index_massden > 0      ) scalars(index_massden,k,iCell) = scalars(index_massden,k+1,iCell)
-                endif
                 if ( associated(index_smoke_fine  )) then
                    if (index_smoke_fine > 0   ) scalars(index_smoke_fine,k,iCell) = scalars(index_smoke_fine,k+1,iCell)
                 endif
@@ -8778,10 +8758,9 @@ call mpas_log_write('Done with soil consistency check')
       deallocate(sorted_arr)
       deallocate(sorted_arrQ1,sorted_arrQ2,sorted_arrQ3,sorted_arrQ4,sorted_arrQ5,sorted_arrQ6,sorted_arrQ7,sorted_arrQ8,sorted_arrQ9,sorted_arrQ10)
 ! Chemistry
-      if (associated(index_massden     )) deallocate(sorted_arrQ11)
-      if (associated(index_smoke_fine  )) deallocate(sorted_arrQ12)
-      if (associated(index_dust_fine   )) deallocate(sorted_arrQ14)
-      if (associated(index_dust_coarse )) deallocate(sorted_arrQ15)
+      if (associated(index_smoke_fine  )) deallocate(sorted_arrQ11)
+      if (associated(index_dust_fine   )) deallocate(sorted_arrQ12)
+      if (associated(index_dust_coarse )) deallocate(sorted_arrQ13)
 
       ! Diagnose the water vapor mixing ratios:
       global_sh_min = 0._RKIND

--- a/src/core_init_atmosphere/registry.chemistry.xml
+++ b/src/core_init_atmosphere/registry.chemistry.xml
@@ -81,9 +81,6 @@
         <var_struct name="state" time_levs="1">
                 <var_array name="scalars" type="real" dimensions="nVertLevels nCells Time" packages="met_stage_out">
 
-                      <var name="MASSDEN" array_group="chemistry" units="kg kg^{-1}"
-                           description="fine smoke mixing ratio"/>
-
                       <var name="smoke_fine" array_group="chemistry" units="kg kg^{-1}"
                            description="fine smoke mixing ratio"
                            packages="mpas_smoke_in"/>
@@ -109,16 +106,11 @@
 
                         <var name="lbc_dust_coarse" array_group="chemistry"  packages="mpas_dust_in" units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of coarse dust mixing ratio"/>
-
-                        <var name="lbc_MASSDEN" array_group="chemistry" units="kg kg^{-1} s^{-1}"
-                             description="Lateral boundary tendency of fine smoke mixing ratio"/>
                 </var_array>
 
         </var_struct>
 
         <var_struct name="fg" time_levs="1">
-                <var name="MASSDEN_fg" name_in_code="MASSDEN" type="real" dimensions="nFGLevels nCells Time" units="kg^{-1}"
-		     description="First guess smoke aerosols"/>
                 <var name="smoke_fine_fg" name_in_code="smoke_fine" type="real" dimensions="nFGLevels nCells Time" units="kg^{-1}"
 		     packages="mpas_smoke_in;mpas_anthro_in" description="First guess fine smoke aerosols"/>
                 <var name="dust_fine_fg" name_in_code="dust_fine" type="real" dimensions="nFGLevels nCells Time" units="kg^{-1}"


### PR DESCRIPTION
Previously, if SMKF, DSTF, or DSTC were in the Vtable, the init program would attempt to fill the scalar array with IC/BCs even when smoke/dust schemes were turned off. 

This fix checks to see whether those schemes are activated.

We also removed references to MASSDEN and are keeping smoke_fine instead.
